### PR TITLE
Update MetamodelUML.md - Gegevensgroep mag voorlopig historie houden

### DIFF
--- a/MetamodelUML.md
+++ b/MetamodelUML.md
@@ -334,6 +334,9 @@ De gegevensgroepen worden naar de volgende aspecten gespecificeerd:
 | **Datum opname**     | 1            | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
 | **Kardinaliteit**    | 1                  | Algemeen metagegeven.                                  | *lowerValue en upperValue van de metaclass Multiplicity Element* |      | *Multiplicity van de source role van de bijbehorende composite relatie* |            |
 | **Authentiek**                   | 1                  | Algemeen metagegeven.                                  |                                                              |      | *Tagged value*                                               |            |
+| **Indicatie materiële historie √**          | 0..1                  | Algemeen metagegeven - vereist een duiding in een extentie hoe dit zich verhoudt tot ditzelfde metagegeven in de kenmerken in het gegevensgroeptype.    |      | *Tagged value* |            |
+| **Indicatie formele historie √**            | 0..1                  | Algemeen metagegeven - vereist een duiding in een extentie hoe dit zich verhoudt tot ditzelfde metagegeven in de kenmerken in het gegevensgroeptype.                                        |                                                              |      | *Tagged value* |            |
+
 | **heeft gegevensgroeptype**   | 1       | Binding aan een gegevensgroeptype.     | *owned element* = UML-Class |    | *type* = Class          |     |
 
 **Specificatie voor «Gegevensgroeptype»**


### PR DESCRIPTION
Vanwege knoop doorgehakt in https://github.com/Geonovum/MIM-Werkomgeving/issues/224 
Historie op gegevensgroep mag. 
Aangegeven als opmerking; vereist een duiding in een extensie hoe dit zich verhoudt tot ditzelfde metagegeven in de kenmerken in het gegevensgroeptype.

De duiding kan zijn: bij een attribuutsoort in een gegevensgroep kan bij de historie metagegevens staan: zie gegevensgroep (dit neem je op in een extensie, zodat naast ja en nee ook zie groep mag). 
De duiding kan zijn: dit overerft naar alle kenmerken die in het gegevensgroeptype die het type is van deze gegevensgroep gemodelleerd zijn. 

Software die model-gedreven verder werkt met het informatiemodel kan dan met deze duiding aan de slag.