### PR TITLE
fix schrijfwijze

### DIFF
--- a/AfsprakenRegels.md
+++ b/AfsprakenRegels.md
@@ -42,16 +42,16 @@ Dit wordt gedaan in een metagegeven lengte. De data van het attribuut moet dan
 voldoen aan het datatype én aan het metagegeven lengte. De lengte wordt dus niet
 in het datatype zelf vastgelegd.
 
-#### Primitive datatypes
+#### Primitive datatypen
 
 Dit metamodel onderkend (momenteel) de volgende extern gedefinieerde primitive
-datatypes. Deze zijn allemaal gebaseerd op [[!GAB]]:
+datatypen. Deze zijn allemaal gebaseerd op [[!GAB]]:
 
 | **Primitive type** | **Betekenis**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | CharacterString    | Zie [[!iso-19103]]. Vrij vertaald: alle alfanumerieke tekens en speciale tekens die horen bij de gekozen characterset (standaard UTF-8), dus met diakrieten, white spaces, \\-teken en newlines of HTML opmaak e.d. Mag starten met spatie. De maximale lengte is onbepaald. *Opmerking*: getallen (ISO Numbers) met voorloopnullen worden opgenomen als CharacterString, met een patroon of formeel patroon. Bij het metagegeven Waardenverzameling attribuutsoort wordt dit dan (ook) gespecificeerd. |
 | Integer            | Zie [[!iso-19103]] (subtype van ISO Number). Vrij vertaald: geheel getal, lengte is minimaal 1 en maximale lengte is onbepaald, zonder voorloopnullen. *Opmerking*: t.a.v. positieve en negatieve getalen en + en – tekens: bijvoorbeeld -2,0 Het (formeel) patroon geeft aan of een + en/of - teken gebruikt mag worden in het gegeven.                                                                                                                                                                |
-| Real               | Zie [[!iso-19103]] (subtype van ISO Number). Vrij vertaald: een real is een zwevendekommagetal, waarbij de precisie bepaald wordt door het aantal getoonde cijfers. Het getoonde getal is een schatting en geeft niet noodzakelijk de exacte waarde weer. *Opmerking 1*: Dit verschilt van decimal, want decimal is een exacte waarde en real is geschat. *Opmerking 2:* t.a.v. positieve en negatieve getalen en + en – tekens: zie [Integer](#primitive-datatypes).                                                           |
+| Real               | Zie [[!iso-19103]] (subtype van ISO Number). Vrij vertaald: een real is een zwevendekommagetal, waarbij de precisie bepaald wordt door het aantal getoonde cijfers. Het getoonde getal is een schatting en geeft niet noodzakelijk de exacte waarde weer. *Opmerking 1*: Dit verschilt van decimal, want decimal is een exacte waarde en real is geschat. *Opmerking 2:* t.a.v. positieve en negatieve getalen en + en – tekens: zie [Integer](#primitive-datatypen).                                                           |
 | Decimal            | Zie [[!iso-19103]] (subtype van ISO Number). Vrij vertaald: een decimal is een gegevenstype waarin het getal een exacte waarde vertegenwoordigt, als een eindige weergave van een decimaal getal. Aangezien veel valuta's decimaal zijn, hebben deze weergaven de voorkeur bij het omgaan met dergelijke waarden. *Opmerking 1:* Dit verschilt van real, want real is een geschatte waarde en Decimal is exact. *Opmerking 2:* t.a.v. positieve en negatieve getalen en + en – tekens: zie Integer.       |
 | Boolean            | Indicatie met mogelijke waarden True, false, 1 of 0. True en 1 hebben een identieke betekenis: Ja. False en 0 hebben een identieke betekenis: Nee. *Opmerking*: t.a.v. Ja of Nee. Wanneer u de Ja of Nee wilt gebruiken, gebruik dan bv. een Enumeratie genaamd Indicatie, of gebruik AN met een lengte en een (formeel) patroon.                                                                                                                                                                       |
 |                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -63,7 +63,7 @@ datatypes. Deze zijn allemaal gebaseerd op [[!GAB]]:
 |                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | URI                | Unieke identificatie op internet conform RFC3986 en de URI-strategie Linked Open Data. Gestandaardiseerde manier om op het internet dingen (pagina's met informatie, objecten, datasets) uniek te identificeren.                                                                                                                                                                                                                                                                                        |
 
-Het is mogelijk om in de eigen extensie extra primitive datatypes op te nemen,
+Het is mogelijk om in de eigen extensie extra primitive datatypen op te nemen,
 zodat deze ook beschikbaar komen voor het informatiemodel.
 
 **Getallen en negatieve getallen**
@@ -110,7 +110,7 @@ toegestaan: [0-9]{4}.
 
 Het is ook mogelijk om in het eigen informatiemodel een eigen datatype te
 definiëren in de vorm van een «Primitief datatype», «Codelijst» of
-«Referentielijst». Zelf gedefinieerde datatypes hebben altijd een eigen
+«Referentielijst». Zelf gedefinieerde datatypen hebben altijd een eigen
 definitie en optioneel een eigen patroon of formeel patroon.
 
 **Voorbeelden** hiervan, die niet tot MIM behoren, maar ter illustratie zijn
@@ -132,7 +132,7 @@ aangeeft dat het om een 2 dimensionale geometrie gaat.
 
 Datatypen Generalisatie
 
-De gele datatypes zijn extern aan het model.
+De gele datatypen zijn extern aan het model.
 
 Het type modelelement (stereotype) verandert niet door de generalisatie. Een
 zelf gedefinieerd primitief datatype zal een generalisatie hebben met een ander
@@ -187,7 +187,7 @@ Gestructureerd datatype zijn).
 
 Soms is er de behoefte om een combinatie van gegevens samengesteld te
 representeren, in één gegevenselement. Dit speelt specifiek bij gestructureerde
-datatypes, omdat de data-elementen hiervan uniek identificerend zijn voor een
+datatypen, omdat de data-elementen hiervan uniek identificerend zijn voor een
 object. De samengestelde representatie verandert niets aan de semantische
 definitie. Om een uniforme samenstelling te waarborgen, wordt er bij het
 gestructureerde datatype een patroon of een formeel patroon gedefinieerd (dat
@@ -268,7 +268,7 @@ semantiek.
     informatiemodel. Een gegevensgroep in een conceptueel model is en blijft dus
     altijd ook een gegevensgroep in een logisch informatiemodel.
 
-### Keuze tussen datatypes (Keuze)
+### Keuze tussen datatypen (Keuze)
 
 Wanneer het datatype van een attribuutsoort een keuze uit twee of meer datatypen
 is, dan wordt dit gemodelleerd met het datatype Keuze. Elk keuze element van de
@@ -730,7 +730,7 @@ In bepaalde situaties is het mogelijk dat een ander informatiemodel al één op
 één de specificaties in UML bevat die relevant zijn voor het eigen
 informatiemodel. Dit is in het bijzonder het geval als het andere
 informatiemodel ook dit metamodel volgt, maar kan ook het geval zijn bij
-gestandaardiseerde datatypes.  
+gestandaardiseerde datatypen.  
 Het is dan wenselijk om hiernaar te kunnen verwijzen. Dit kan door deze packages
 over te nemen naar de eigen UML tool en het stereotype «extern» toe te kennen.
 Deze packages worden dan wel buiten het eigen informatiemodel gehouden. Ze zijn
@@ -863,7 +863,7 @@ informatiemodel zelf (zie ook [bijlage](#bijlagen)).
 #### Uniekheid van namen van modelelementen 
 
 * Objecttypes hebben een unieke naam binnen het hele informatiemodel
-* Datatypes hebben een unieke naam binnen het informatiemodel 
+* Datatypen hebben een unieke naam binnen het informatiemodel 
 * Kenmerken van een objecttype hebben een unieke naam binnen het objecttype (attribuutsoort, gegevensgroep, relatiesoort et cetera)
 * De naam van kenmerken van een objecttype hoeven niet uniek te zijn over objecttypen heen.
 * De naam van elementen van een datatype hoeven niet uniek te zijn over datatypen heen.
@@ -884,7 +884,7 @@ Dit betekent expliciet niet dat kernmerken van verschillende objecten, met dezel
 
 Met natuurlijke taal wordt bedoeld, zoals de gebruikers erover praten, in
 normaal Nederlands. Veelal zijn dit alleen letters en cijfers, met spaties.
-Koppeltekens (‘-’ of ‘_’) kunnen gebruikt worden, indien gewenst, alsmede
+Koppeltekens (`-` of `_`) kunnen gebruikt worden, indien gewenst, alsmede
 diakrieten.
 
 Zo kan bijvoorbeeld gekozen worden dat de eerste letter een hoofdletter is voor
@@ -899,7 +899,7 @@ gehanteerd.
 
 Met machine leesbare taal wordt bedoeld dat deze eenvoudig door systemen te
 verwerken is. Veelal zijn dit alleen letters en cijfers, zonder spaties, zonder
-diakrieten. Koppeltekens (‘-’ of ‘_’) kunnen gebruikt worden, maar dit wordt
+diakrieten. Koppeltekens (`-` of `_`) kunnen gebruikt worden, maar dit wordt
 veelal vermeden.
 
 Zo kan bijvoorbeeld gekozen worden voor UpperCamelCase voor namen van

--- a/MetamodelAlgemeen.md
+++ b/MetamodelAlgemeen.md
@@ -389,7 +389,7 @@ gelden worden in een generiek objecttype, het supertype, gemodelleerd en deze
 worden overerft door elk subtype (minimaal twee) die de generalisatie relatie
 legt naar dit generieke objecttype.
 
-Generalisatie tussen datatypes:
+Generalisatie tussen datatypen:
 
 Het meer specifieke datatype brengt een verbijzondering aan in de vorm van een
 meer restrictieve definitie, of een meer restrictief patroon/formeel patroon.
@@ -399,7 +399,7 @@ DMO en dient als basis voor een zelf te definiëren datatype (zie [Datatype zelf
 definiëren](#datatype-zelf-definieren)), zoals een CharacterString Postcode, of
 een NietNegatiefGetal.
 
-Deze generalisatie is van toepassing op de volgende datatypes: «Primitief
+Deze generalisatie is van toepassing op de volgende datatypen: «Primitief
 datatype», «Gestructureerd datatype», «Referentielijst», «Codelijst»,
 «Enumeratie».
 
@@ -585,7 +585,7 @@ Bij elke «Attribuutsoort» wordt gespecificeerd aan welk datatype de data c.q. 
 waarde die hiervoor vastgelegd wordt moet voldoen. Het datatype wordt gebruikt
 als type van een attribuutsoort.
 
-Datatypes zijn veelal op vele plekken (her)bruikbaar en kunnen daarom gespecificeerd
+Datatypen zijn veelal op vele plekken (her)bruikbaar en kunnen daarom gespecificeerd
 worden bij diverse «Attribuutsoort»-en.
 
 Diagram: [Datatypen](#datatypen)
@@ -602,14 +602,14 @@ zelf geen eigen modelelementen zoals een «Data element». Ook is er geen sprake
 
 Een primitief datatype kan een standaard datatype zijn, zoals CharacterString, Integer enz. Het metamodel volgt hierbij de definities zoals beschreven in de ISO standaarden (zie
 §3.1).
-* Deze datatypes hebben altijd al een naam en definitie gekregen vanuit deze standaarden en deze worden gebruikt.
-* Deze datatypes hebben geen MIM metaclass.
+* Deze datatypen hebben altijd al een naam en definitie gekregen vanuit deze standaarden en deze worden gebruikt.
+* Deze datatypen hebben geen MIM metaclass.
 
 Een primitief datatype kan ook in het eigen informatiemodel zelf gedefinieerd zijn, zoals bijvoorbeeld een primitief datatype AN: een alfanumerieke CharacterString conform de MES-1 specificatie (oftewel zonder bijzondere karakters zoals een smiley en zonder bijzondere tekens uit niet Europese talen).
-* Dit is een zelf gedefinieerde variant die als basis een van de voorgaande standaard datatypes heeft, zoals CharacterString. Dit standaard datatype moet eenduidig aangegeven worden (zie generalisatie bij datatypes, of door in een extensie aan te geven wat de default is, bv. CharacterString).
+* Dit is een zelf gedefinieerde variant die als basis een van de voorgaande standaard datatypen heeft, zoals CharacterString. Dit standaard datatype moet eenduidig aangegeven worden (zie generalisatie bij datatypen, of door in een extensie aan te geven wat de default is, bv. CharacterString).
 * Hierbij hoort de MIM metaclass gespecificeerd te worden: `primitief datatype`.
 
-Een informatiemodel definieert zelf datatypes als er behoefte is aan een datatype dat
+Een informatiemodel definieert zelf datatypen als er behoefte is aan een datatype dat
 eenmalig gedefinieerd wordt en op meerdere plekken in het model gebruikt moet
 kunnen worden met altijd exact dezelfde structuur en waardenbereik (zie ook
 ‘patroon’ in [Domeinwaarden of lijsten](#domeinwaarden-of-lijsten)). Dit
@@ -781,7 +781,7 @@ Een objecttype heeft een attribuutsoort en het datatype hiervan is ofwel datatyp
 Voorbeeld: *Attribuutsoort* geometrie als kenmerk van een objecttype. Dit is een keuze uit *Datatype* Line of *Datatype* Polygon. De opsomming van beide keuzemogelijkheden noemen we de *Keuze* LineOrPolygon. De aanhaking aan het attribuutsoort geometrie gebeurt door aan te geven dat LineOrPolygon het type is van geometrie.
 </aside>
 
-In dit voorbeeld vormt LineOrPolygon de *Keuze* als geheel. De datatypes zelf zijn de keuze mogelijkheden, maar blijven in de modellering van de metaclass datatype en behoren in deze zin niet tot de modellering van de metaclass keuze.  
+In dit voorbeeld vormt LineOrPolygon de *Keuze* als geheel. De datatypen zelf zijn de keuze mogelijkheden, maar blijven in de modellering van de metaclass datatype en behoren in deze zin niet tot de modellering van de metaclass keuze.  
 
 Het is niet de bedoeling om twee attribuutsoorten te modelleren met elk een datatype en de attribuutsoorten optioneel te maken.
 

--- a/MetamodelUML.md
+++ b/MetamodelUML.md
@@ -134,7 +134,7 @@ Dit UML is uitgewerkt voor Objecttype. Voor Gegevensgroeptype en Relatieklasse g
 
 Modellering van deze Keuze in een informatiemodel: 
 - Modelleer een _UML-Datatype_ met stereotype _keuze_. 
-- Modelleer hierin 2 of meer MIM-Datatypes: neem hiervoor eerst een _UML-attribute_ met stereotype _keuze_ op in de Keuze zoals gemodelleerd in punt 1, dit UML-attribute krijgt als typering het gewenste (MIM) Datatype. Merk op dat dit extra UML-attribute is zelf geen keuze mogelijkheid is, de keuze is immers tussen de datatypes. 
+- Modelleer hierin 2 of meer MIM-Datatypen: neem hiervoor eerst een _UML-attribute_ met stereotype _keuze_ op in de Keuze zoals gemodelleerd in punt 1, dit UML-attribute krijgt als typering het gewenste (MIM) Datatype. Merk op dat dit extra UML-attribute is zelf geen keuze mogelijkheid is, de keuze is immers tussen de datatypen. 
 
 Gebruik de Keuze voor een (MIM) Attrituutsoort: 
 - Kies een _MIM-Attribuutsoort_ en koppel de hiervoor gemodelleerde Keuze hieraan via een typering, zoals gebruikelijk. 
@@ -192,7 +192,7 @@ Er zijn drie metaklassen met de naam Keuze maar elke keer als extensie van een a
 | Keuze             | Keuze          | (UML) Property        |      | Attribute    |            |
 
 - Als een UML Class met stereotype keuze is gebruikt, dan zitten hierin alleen attribuutsoorten en/of relatiedoelen, de attribuutsoorten en relatiedoelen waaruit gekozen kan worden. 
-- Als een UML Datatype met stereotype keuze is gebruikt, dan zitten hierin alleen datatypes, de datatypes waaruit gekozen kan worden. 
+- Als een UML Datatype met stereotype keuze is gebruikt, dan zitten hierin alleen datatypen, de datatypen waaruit gekozen kan worden. 
 - Als een UML Property met stereotype keuze is gebruikt, dan is er sprake van een hulpconstructie om het modelelement Keuze aan te koppelen aan het MIM-modelelement waarvoor de keuze geldt.
 
 Merk op dat deze tabel niet gaat over de modelelementen waaruit een keuze gemaakt moet worden. Dat zijn immers de modelelementen datatype, attribuutsoort en relatiesoort. Deze tabel gaat over de modellering van Keuze in UML oftewel de extra hulpconstructies die in UML nodig zijn om de modelelementen waaruit een keuze gemaakt moet worden aan te koppelen aan het MIM-modelelement waarvoor de keuze geldt. Deze extra hulpconstructies krijgen als stereotype _keuze_ en dit geeft aan dat de betekenis hiervan anders is dan de betekenis van de MIM-elementen datatype, attirbuutsoort en relatiesoort. 
@@ -488,7 +488,7 @@ De generalisaties worden naar het volgende aspect gespecificeerd:
 | **Datum opname** | 1               | Algemeen metagegeven                                         |                     |      | *Tagged value* |            |
 
 
-#### «Generalisatie» tussen datatypes
+#### «Generalisatie» tussen datatypen
 
 De generalisaties worden naar het volgende aspect gespecificeerd:
 

--- a/TransformatieRDF.md
+++ b/TransformatieRDF.md
@@ -324,7 +324,7 @@ WHERE {
 
 > De typering van het hiërarchische verband tussen een meer generiek en een meer specifiek modelelement van hetzelfde soort, waarbij het meer specifieke modelelement eigenschappen van het meer generieke modelelement overerft.
 
-Generalisatie kan gebruikt worden tussen objecttypen, maar ook tussen datatypes. Aangezien zowel objecttypen als datatypen in het RDFS gebaseerde model worden getransformeerd naar een subklasse van `rdfs:Class`, kan in beide gevallen gebruik worden gemaakt van dezelfde transformatie.
+Generalisatie kan gebruikt worden tussen objecttypen, maar ook tussen datatypen. Aangezien zowel objecttypen als datatypen in het RDFS gebaseerde model worden getransformeerd naar een subklasse van `rdfs:Class`, kan in beide gevallen gebruik worden gemaakt van dezelfde transformatie.
 
 Een `mim:Generalisatie` wordt vertaald naar een `rdfs:subClassOf`.
 
@@ -472,7 +472,7 @@ WHERE {
 
 > Een lijst met een opsomming van de mogelijke domeinwaarden van een attribuutsoort, die buiten het model in een externe waardenlijst worden beheerd. De domeinwaarden in de lijst kunnen in de loop van de tijd aangepast, uitgebreid, of verwijderd worden, zonder dat het informatiemodel aangepast wordt (in tegenstelling tot bij een enumeratie).
 
-Een waardelijst kan verschillende soorten dingen opsommen. Een lijst met waardes, bijv. een opsomming van nummers, maar ook een lijst met concepten, datatypes, of objecten. Het is dan ook niet triviaal om een goede automatische vertaling te bepalen die een waardelijst kan vertalen naar Linked Data.
+Een waardelijst kan verschillende soorten dingen opsommen. Een lijst met waardes, bijv. een opsomming van nummers, maar ook een lijst met concepten, datatypen, of objecten. Het is dan ook niet triviaal om een goede automatische vertaling te bepalen die een waardelijst kan vertalen naar Linked Data.
 
 Het MIM biedt echt aanknopingspunten hoe een waardelijst gemodelleerd dient te worden:
 
@@ -1216,8 +1216,8 @@ Een `mim:locatie` wordt direct, zonder aanpassing, overgenomen in het vertaalde 
 
 De vertaling van een `mim:type` hangt af van de vertaling van het datatype waar naar wordt verwezen:
 
-- Voor primitieve datatypes wordt vertaald naar een `sh:datatype`;
-- Voor gestructureerde datatypes wordt vertaald naar een `sh:node`;
+- Voor primitieve datatypen wordt vertaald naar een `sh:datatype`;
+- Voor gestructureerde datatypen wordt vertaald naar een `sh:node`;
 - Voor een enumeratie wordt vertaald naar een `sh:node`;
 - Voor een referentielijst wordt vertaald naar een `sh:node`;
 - Voor een codelijst wordt vertaald naar een `sh:node`;


### PR DESCRIPTION
Het meervoud van datatype kwam op twee manieren voor; nu is dat geüniformeerd naar één schrijfwijze: datatypen