### PR TITLE
 Op welke model elementen zit historie #224

### DIFF
--- a/MetamodelUML.md
+++ b/MetamodelUML.md
@@ -381,6 +381,24 @@ Alleen toevoegen als het attribuutsoort een waarde van een meting of waarnemimg 
 | -------------------------------- | -------- | ---------------------------------------- | ------------------------------------- | -- | -------------- | -------- |
 | **Eenheid**  |0..1      | Alleen opnemen bij een meetgegeven of waarneming     | |    | *Tagged value*          |     |
 
+#### «Gegevensgroep»
+
+De gegevensgroepen worden naar de volgende aspecten gespecificeerd:
+
+| **Aspect**                  | **Kardinaliteit** | **Toelichting**                | **In UML 2.5**                        |    | **In EA**      | **In ...** |
+| -------------------------------- | -------- | ---------------------------------------- | ------------------------------------- | -- | -------------- | -------- |
+| **Naam**             | 1            | Algemeen metagegeven. | *name van de metaclass Named element* |    | *Name*         |     |
+| **Alias**            | 0..1         | Algemeen metagegeven. | *UML-Property*                        |    | *Alias*        |     |
+| **Herkomst**         | 1            | Algemeen metagegeven. |                                       |    | *tagged value* |     |
+| **Begrip**           | 0..\*        | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
+| **Definitie**        | 1            | Algemeen metagegeven. | *Body van de metaclass Comment*       |    | *Notes*        |     |
+| **Herkomst definitie** | 1          | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
+| **Toelichting√**     | 0..1         | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
+| **Datum opname**     | 1            | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
+| **Kardinaliteit**    | 1            | Algemeen metagegeven. | *lowerValue en upperValue van de metaclass Multiplicity Element* |      | *Multiplicity van de source role van de bijbehorende composite relatie* |            |
+| **Authentiek**       | 1            | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
+| heeft **gegevensgroeptype**   | 1   | Binding aan een gegevensgroeptype. | *owned element* = UML-Class | | *type* = Class |     |
+
 #### «Gegevensgroeptype»
 
 De gegevensgroeptypen worden naar de volgende aspecten gespecificeerd:
@@ -404,25 +422,6 @@ De gegevensgroeptypen worden naar de volgende aspecten gespecificeerd:
 | heeft **externe koppeling**       | 0..*               | Binding aan een externe koppeling.                                 | *owned element* = UML-Relationship                              |     | *association*  |            |
 | verwijst naar **supertype**       | 0..*               | Binding aan een generalisatie (naar een ander gegevensgroeptype).  | *owned element* = UML-Relationship                              |     | *association*  |            |
 
-#### «Gegevensgroep»
-
-De gegevensgroepen worden naar de volgende aspecten gespecificeerd:
-
-| **Aspect**                  | **Kardinaliteit** | **Toelichting**                | **In UML 2.5**                        |    | **In EA**      | **In ...** |
-| -------------------------------- | -------- | ---------------------------------------- | ------------------------------------- | -- | -------------- | -------- |
-| **Naam**             | 1            | Algemeen metagegeven. | *name van de metaclass Named element* |    | *Name*         |     |
-| **Alias**            | 0..1         | Algemeen metagegeven. | *UML-Property*                        |    | *Alias*        |     |
-| **Herkomst**         | 1            | Algemeen metagegeven. |                                       |    | *tagged value* |     |
-| **Begrip**           | 0..\*        | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
-| **Definitie**        | 1            | Algemeen metagegeven. | *Body van de metaclass Comment*       |    | *Notes*        |     |
-| **Herkomst definitie** | 1          | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
-| **Toelichting√**     | 0..1         | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
-| **Datum opname**     | 1            | Algemeen metagegeven. |                                       |    | *Tagged value* |     |
-| **Kardinaliteit**    | 1                  | Algemeen metagegeven.                                  | *lowerValue en upperValue van de metaclass Multiplicity Element* |      | *Multiplicity van de source role van de bijbehorende composite relatie* |            |
-| **Authentiek**                   | 1                  | Algemeen metagegeven.                                  |                                                              |      | *Tagged value*                                               |            |
-| **Indicatie materiële historie √**          | 0..1                  | Algemeen metagegeven - vereist een duiding in een extentie hoe dit zich verhoudt tot ditzelfde metagegeven in de kenmerken in het gegevensgroeptype.    |      | *Tagged value* |            |
-| **Indicatie formele historie √**            | 0..1                  | Algemeen metagegeven - vereist een duiding in een extentie hoe dit zich verhoudt tot ditzelfde metagegeven in de kenmerken in het gegevensgroeptype.                                        |                                                              |      | *Tagged value* |            |
-| heeft **gegevensgroeptype**   | 1       | Binding aan een gegevensgroeptype.     | *owned element* = UML-Class |    | *type* = Class          |     |
 
 ### Specificatie metagegevens voor relaties
 


### PR DESCRIPTION
Zie #224 

Korte beschrijving voor changelog bijlage bij uitbrengen versie:  De metagegevens voor historie kunnen niet (meer) bijgehouden worden op gegevensgroep (dit bijhouden gebeurd bij de specifieke modelelementen binnen het gegevensgroeptype dat bij de gegevensgroep hoort). 

Verwerking nodig in H2, H3, H4 en H6. In H2 een toelichting, in de rest de uitwerking ervan. 

Heeft een sterke relatie met #326 en het H2 deel is al verwerkt in een eigen pull request (stap 1). Dit had ook binnen deze getrokken kunnen worden, maar is in een eigen gebeurd). 

Stap 2: in H3 UML. Deze is gedaan in deze branch: verwijderd dat bij een gegevensgroep indicatie materiele en formele historie bijhouden kan worden. Let op dat deze verwerking niet teruggedraaid wordt bij de verwerking van #151 Historie naamgeving aanpassen

Stap 3: in H4 LD. 
In de tekst bij https://docs.geostandaarden.nl/mim/mim/#modellering-metagegevens-voor-objecten-en-attributen-in-ld staat het nog wel, echter in de tekst on de source file https://github.com/Geonovum/MIM-Werkomgeving/blob/master/MetamodelLD.md staat het niet meer. Mogelijk heeft iemand dit al verwerkt. 

In de diagrammen is het nog niet verwerkt! @pmaria kan jij de diagrammen aanpassen?

H6 lijkt niet geraakt te worden door deze wijziging, maar dit kan ik niet met zekerheid zeggen. @pmaria kan jij hier ook naar kijken? Kan samen. 