### PR TITLE
issue 285

### DIFF
--- a/MetamodelAlgemeen.md
+++ b/MetamodelAlgemeen.md
@@ -1871,7 +1871,7 @@ Een package `«Domein»` met de naam `Activiteiten` bevat `«Objecttype»` `Werk
 *Toepassing*: Package, Informatiemodel, Domein, Extern, View.
 
 #### Metagegeven: **bevat enumeratiewaarde**
-Verkorte schrijfwijze: **enumeratiewaarde**
+Verkorte schrijfwijze: **waarde**
 
 <aside class="definition">
   <dfn>bevat enumeratie waarde</dfn>De binding van een enumeratiewaarde aan een enumeratie.


### PR DESCRIPTION
bevat enumeratiewaarde heeft als verkorte schrijfwijze enumeratiewaarde terwijl dit in de ld implementatie waarde heet. Voor de LD implementatie was dit een breaking change. Voor de 1.2 versie wordt daarom de verkorte schrijfwijze 'waarde'.