### PR TITLE
Markeer bijlagen ook als bijlagen

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,13 +45,11 @@
     <section data-include-format="markdown" data-include="MetamodelUML.md"><h2>MetaUML</h2></section>
     <section data-include-format="markdown" data-include="MetamodelLD.md"><h2>MetamodelLD</h2></section>
     <section data-include-format="markdown" data-include="AfsprakenRegels.md"><h2>AfsprakenRegels</h2></section>
-    <section><h2>Bijlagen</h2>
-      <section data-include-format="markdown" data-include="Diagrammen.md"></section>
-      <section data-include-format="markdown" data-include="TemplateNaamgevingsconventies.md"></section>
-      <section data-include-format="markdown" data-include="VertalingEngels.md"></section>
-      <section data-include-format="markdown" data-include="TransformatieRDF.md"></section>
-      <section data-include-format="markdown" data-include="Versielog.md"></section>
-    </section>
+    <section class="appendix" data-include-format="markdown" data-include="Diagrammen.md"></section>
+    <section class="appendix" data-include-format="markdown" data-include="TemplateNaamgevingsconventies.md"></section>
+    <section class="appendix" data-include-format="markdown" data-include="VertalingEngels.md"></section>
+    <section class="appendix" data-include-format="markdown" data-include="TransformatieRDF.md"></section>
+    <section class="appendix" data-include-format="markdown" data-include="Versielog.md"></section>
     <section id='conformance'></section>
     <section id='tof'></section>
     <section id="index"></section>


### PR DESCRIPTION
Respec kent het principe "appendix" wat de verzamelterm is voor secties bijlagen zijn: https://respec.org/docs/#appendix Hier vallen de huidige bijlagen zoals voorbeelden onder.

Dit heeft geen impact op de normativiteit van de bijlagen, want die is onafhankelijk van waar ze staan in het document.